### PR TITLE
allow optional substitution of custom Promise/A+ library

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "mochawesome": "^3.0.2",
     "native-promise-only": "^0.8.1",
     "nyc": "^12.0.1",
+    "rsvp": "^4.8.2",
     "sinon": "^5.0.10",
     "uuid": "^3.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -5,11 +5,17 @@
   "main": "src/main.js",
   "license": "MIT",
   "devDependencies": {
+    "bluebird": "^3.5.1",
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
     "mochawesome": "^3.0.2",
+    "native-promise-only": "^0.8.1",
     "nyc": "^12.0.1",
     "sinon": "^5.0.10",
     "uuid": "^3.2.1"
-  }
+  },
+  "scripts": {
+    "test:unit": "yarn nyc mocha --report=mochawesome ./test/unit/**/*.js"
+  },
+  "dependencies": {}
 }

--- a/src/promisify.js
+++ b/src/promisify.js
@@ -1,5 +1,5 @@
-const promisify = fn => (...promisifyArgs) =>
-  new Promise((resolve, reject) => {
+const promisify = (fn, promiseLibrary = Promise) => (...promisifyArgs) => {
+  return new promiseLibrary((resolve, reject) => {
     promisifyArgs.push((error, result) => {
       if (error) reject(error);
       resolve(result);
@@ -7,6 +7,7 @@ const promisify = fn => (...promisifyArgs) =>
 
     fn(...promisifyArgs);
   });
+};
 
 module.exports = {
   promisify,

--- a/test/unit/promisify.js
+++ b/test/unit/promisify.js
@@ -33,11 +33,11 @@ describe("promise_util.js", () => {
     const testFn = (numberOfArguments, promiseLibrary) => (mockFn, expected) => {
       const args = new Array(numberOfArguments).map(() => uuid());
 
-      const isCustomPromise = !!promiseLibrary;
+      const isCustomPromise = promiseLibrary !== undefined && promiseLibrary !== null;
       let promiseLibrarySpy;
 
       let promisifyTest;
-      if (promiseLibrary !== undefined && promiseLibrary !== null) {
+      if (isCustomPromise) {
         promiseLibrarySpy = spy(promiseLibrary);
         promisifyTest = promisify(mockFn, promiseLibrarySpy);
       } else {

--- a/test/unit/promisify.js
+++ b/test/unit/promisify.js
@@ -3,6 +3,7 @@ const { spy } = require("sinon");
 const uuid = require("uuid");
 const bluebird = require("bluebird");
 const nativePromiseOnly = require("native-promise-only");
+const RSVP = require("rsvp").Promise;
 
 const { promisify } = require("../../src/promisify");
 
@@ -95,6 +96,9 @@ describe("promise_util.js", () => {
     });
     describe('when using nativePromiseOnly (a custom Promise/A+ library)', () => {
       testBattery(nativePromiseCallSet.map(el => testFn(el, nativePromiseOnly)));
+    });
+    describe('when using RSVP (a custom Promise/A+ library)', () => {
+      testBattery(nativePromiseCallSet.map(el => testFn(el, RSVP)));
     });
   });
 });

--- a/test/unit/promisify.js
+++ b/test/unit/promisify.js
@@ -8,7 +8,7 @@ const RSVP = require("rsvp").Promise;
 const { promisify } = require("../../src/promisify");
 
 describe("promise_util.js", () => {
-  describe("promisify,", () => {
+  describe("promisify", () => {
     let passingUuid;
     let errorUuid;
     let fnSpy;
@@ -65,7 +65,7 @@ describe("promise_util.js", () => {
 
     promiseLibs.forEach((promiseLib, index) => {
       describe(`when using ${
-        index < 1 ? "native Promises," : "Promise library " + index + ","
+        index < 1 ? "native Promises," : "Promise library " + index
       }`, () => {
         it("should promise to execute a standard callback function with a 0 argument signature like (callback)", () => {
           return testFn(0, spy(promiseLib))(createPassMockFn(), passingUuid);

--- a/test/unit/promisify.js
+++ b/test/unit/promisify.js
@@ -65,7 +65,7 @@ describe("promise_util.js", () => {
 
     promiseLibs.forEach((promiseLib, index) => {
       describe(`when using ${
-        index < 1 ? "native Promises," : "Promise library " + index
+        index < 1 ? "native Promises " : "Promise library " + index
       }`, () => {
         it("should promise to execute a standard callback function with a 0 argument signature like (callback)", () => {
           return testFn(0, spy(promiseLib))(createPassMockFn(), passingUuid);

--- a/test/unit/promisify.js
+++ b/test/unit/promisify.js
@@ -28,7 +28,7 @@ describe("promise_util.js", () => {
     const createPassMockFn = () => createMockFn(undefined, passingUuid);
     const createFailMockFn = () => createMockFn(errorUuid, undefined);
 
-    const nativePromiseCallSet = [0,1,2,10,10];
+    const promiseLibs = [undefined, bluebird, nativePromiseOnly, RSVP];
 
     const testFn = (numberOfArguments, promiseLibrary) => (mockFn, expected) => {
       const args = new Array(numberOfArguments).map(() => uuid());
@@ -66,39 +66,28 @@ describe("promise_util.js", () => {
         });
     };
 
-    const testBattery = (callSet) => {
-      it("should promise to execute a standard callback function with a 0 argument signature like (callback)", () => {
-        return callSet.pop()(createPassMockFn(), passingUuid);
-      });
+    promiseLibs.forEach((promiseLib, index) => {
+      describe(`when using ${index < 1 ? 'native Promises,' : 'Promise library ' + index + ','}`, () => {
+        it("should promise to execute a standard callback function with a 0 argument signature like (callback)", () => {
+          return testFn(0, promiseLib)(createPassMockFn(), passingUuid);
+        });
 
-      it("should promise to execute a standard callback function with a 1 argument signature like (a, callback)", () => {
-        return callSet.pop()(createPassMockFn(), passingUuid);
-      });
+        it("should promise to execute a standard callback function with a 1 argument signature like (a, callback)", () => {
+          return testFn(1, promiseLib)(createPassMockFn(), passingUuid);
+        });
 
-      it("should promise to execute a standard callback function with a 2 argument signature like (a, b, callback)", () => {
-        return callSet.pop()(createPassMockFn(), passingUuid);
-      });
+        it("should promise to execute a standard callback function with a 2 argument signature like (a, b, callback)", () => {
+          return testFn(2, promiseLib)(createPassMockFn(), passingUuid);
+        });
 
-      it("should promise to execute a standard callback function with a 10 argument signature like (a, b, c, d, e, f, g, h, i, j, callback)", () => {
-        return callSet.pop()(createPassMockFn(), passingUuid);
-      });
+        it("should promise to execute a standard callback function with a 10 argument signature like (a, b, c, d, e, f, g, h, i, j, callback)", () => {
+          return testFn(10, promiseLib)(createPassMockFn(), passingUuid);
+        });
 
-      it("should reject if called back with an error", () => {
-        return callSet.pop()(createFailMockFn(), errorUuid);
+        it("should reject if called back with an error", () => {
+          return testFn(10, promiseLib)(createFailMockFn(), errorUuid);
+        });
       });
-    };
-
-    describe("when using the native Promise library,", () => {
-      testBattery(nativePromiseCallSet.map(el => testFn(el)));
-    });
-    describe('when using bluebird (a custom Promise/A+ library)', () => {
-      testBattery(nativePromiseCallSet.map(el => testFn(el, bluebird)));
-    });
-    describe('when using nativePromiseOnly (a custom Promise/A+ library)', () => {
-      testBattery(nativePromiseCallSet.map(el => testFn(el, nativePromiseOnly)));
-    });
-    describe('when using RSVP (a custom Promise/A+ library)', () => {
-      testBattery(nativePromiseCallSet.map(el => testFn(el, RSVP)));
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1461,6 +1461,10 @@ rimraf@^2.6.1, rimraf@^2.6.2:
   dependencies:
     glob "^7.0.5"
 
+rsvp@^4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.2.tgz#9d5647108735784eb13418cdddb56f75b919d722"
+
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,6 +187,10 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+bluebird@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1135,6 +1139,10 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 nise@^1.3.3:
   version "1.4.0"


### PR DESCRIPTION
Three Promise/A+ libraries work:
- bluebird
- nativePromiseOnly
- rsvp.js
q was tested and did not work (it does not support the new keyword). It will need a snowflake solution if we want to support it.